### PR TITLE
Handle ISO timestamps properly

### DIFF
--- a/lib/connections/mysql.js
+++ b/lib/connections/mysql.js
@@ -16,6 +16,10 @@ var connection = function(name, type, options, book){
     max_allowed_packet: undefined,
   };
 
+  if(!this.options.timezone){
+    this.options.timezone = 'utc';
+  }
+
   if(!this.options.varCharLength){
     this.options.varCharLength = 255;
   }

--- a/lib/connections/snowflake.js
+++ b/lib/connections/snowflake.js
@@ -466,14 +466,14 @@ function computeDataToBePushed(row, columnData, key) {
 
   if( row[key] !== null && row[key] !== undefined ) {
     if(row[key] instanceof Date === true) {
-      var dbTime = js_yyyy_mm_dd_hh_mm_ss(row[key])
+      var dbTime = row[key].toISOString();
 
       //Explicitly Added a null for invalid timestamps
-      if(dbTime === '0000-00-00 00:00:00') {
+      if(dbTime === '0000-00-00 00:00:00Z') {
         return null;
       }
 
-      return  dbTime
+      return dbTime;
     }
 
     //Add Cast for Boolean valyes to 1 or 0

--- a/lib/connections/snowflake.js
+++ b/lib/connections/snowflake.js
@@ -469,7 +469,7 @@ function computeDataToBePushed(row, columnData, key) {
       var dbTime = row[key].toISOString();
 
       //Explicitly Added a null for invalid timestamps
-      if(dbTime === '0000-00-00 00:00:00Z') {
+      if(dbTime === '0000-00-00T00:00:00Z') {
         return null;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "empujar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "When you need to push data around, you push it. Push it real good.  An ETL and Operations tool.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
When converting from the Date object to a string, be sure to use the ISO format, which will be in UTC timezone.

This means that users of empujar with MySQL will need to add an option to their config:
```
  timezone: 'utc'
```
otherwise empujar's mysql connector will assume you want local timezone, which you almost never want.