### PR TITLE
use q as the query in case of array of queries

### DIFF
--- a/lib/connections/snowflake.js
+++ b/lib/connections/snowflake.js
@@ -117,7 +117,7 @@ connection.prototype.query = function(query, data, callback, skipTransactions){
         query.forEach(function(q){
             steps.push(function(next){
                 var runner = self.query(q, next);
-                self.book.logger.log('   ' + self.name + '/' + self.type + ' >> ' + runner.getSqlText(), 'debug');
+                self.book.logger.log('   ' + self.name + '/' + self.type + ' >> ' + q, 'debug');
             });
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "empujar",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "When you need to push data around, you push it. Push it real good.  An ETL and Operations tool.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Hotfix
Need to use `q` instead of `runner.getSqlText` as the query `q` is passed in the function arguments.