### PR TITLE
upgrade elasticsearch package and pinging process

### DIFF
--- a/lib/connections/elasticsearch.js
+++ b/lib/connections/elasticsearch.js
@@ -17,7 +17,7 @@ var connection = function(name, type, options, book){
 connection.prototype.connect = function(callback){
   var self = this;
   self.connection = new elasticsearch.Client(self.options);
-  self.connection.ping({hello: "elasticsearch!"}, function(error){
+  self.connection.ping({requestTimeout: 30000}, function(error){
     callback(error);
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "empujar",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "When you need to push data around, you push it. Push it real good.  An ETL and Operations tool.",
   "main": "index.js",
   "engines": {
@@ -40,7 +40,7 @@
     "async": "^2.1.1",
     "aws-sdk": "^2.10.0",
     "dateformat": "^2.0.0",
-    "elasticsearch": "^12.1.0",
+    "elasticsearch": "^15.4.0",
     "filesize": "^3.4.1",
     "ftp": "^0.3.10",
     "glob": "^7.1.1",


### PR DESCRIPTION
the upgraded elasticsearch package can talk to upgraded ES of 6.4+
pinging with `hello` is not the ideal way of pinging.

for the elasticsearch connections, we need to update the config files to include `apiVersion` in their option. specifying that will help us talk to different versions of elasticsearch:
e.g. `apiVersion: '1.7'` or `apiVersion: '6.4'`