### PR TITLE
Fix call back on snowflake clearError

### DIFF
--- a/lib/connections/snowflake.js
+++ b/lib/connections/snowflake.js
@@ -390,9 +390,8 @@ connection.prototype.insertData = function(table, data, callback, mergeOnDuplica
 
                                                 if(clearError) {
                                                     self.book.logger.log('Error clearing out temp table for table ' + table + ' . Exiting out...', 'error');
-                                                } else {
-                                                    callback(null, clearRows);
                                                 }
+                                                callback(clearError, clearRows);
 
                                             });
                                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "empujar",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "When you need to push data around, you push it. Push it real good.  An ETL and Operations tool.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
When the call back is not in the log the code will not terminate and it will get stuck. This fix makes sure that the callback is going to happen and terminates the run.