### PR TITLE
DATA-1193 : Adding debug logs

### DIFF
--- a/lib/connections/snowflake.js
+++ b/lib/connections/snowflake.js
@@ -53,7 +53,10 @@ connection.prototype.showTables = function(callback){
     var rows = [];
 
     self.query('SHOW TABLES', function(error, dbRows){
-        if(error){ callback(error); }
+        if(error){ 
+            callback(error); 
+            self.book.logger.log('Error in Show tables' + error.message, 'error');
+        }
         else{
             dbRows.forEach(function(row){
                 rows.push(row['name'])
@@ -536,6 +539,9 @@ connection.prototype.createtemporaryTable = function(table, data, callback, merg
 
 
     self.showTables(function(error, tables){
+
+        self.book.logger.log('Show Tables count : ' + tables.length, 'debug');
+        self.book.logger.log('Checking Table : ' + table, 'debug');
 
         self.showColumns(table, function(error, columnData){
 


### PR DESCRIPTION
Adding debug logs here to identify the root cause of type error. 

Added these logs in debug, so that we run in debug mode and avoid running in trace mode.